### PR TITLE
Fix post hook not resetting state

### DIFF
--- a/CRM/Bpk/DataLogic.php
+++ b/CRM/Bpk/DataLogic.php
@@ -95,6 +95,7 @@ class CRM_Bpk_DataLogic {
       if (self::$reset_recursion) return; // avoid catching own reset
       self::$reset_recursion = TRUE;
       civicrm_api3('Contact', 'create', self::$scheduled_reset);
+      self::$scheduled_reset = NULL;
       self::$reset_recursion = FALSE;
     }
   }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/phpunit/CRM/Bpk/DataLogicTest.php
+++ b/tests/phpunit/CRM/Bpk/DataLogicTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use CRM_Bpk_ExtensionUtil as E;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Test BPK Data Logic
+ *
+ * @group headless
+ */
+class CRM_Bpk_DataLogicTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+  use \Civi\Test\Api3TestTrait;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Test whether BPKs get reset when a field that's relevant for BPK is updated
+   */
+  public function testScheduledResetIsExecuted() {
+    // test twice to ensure no state is preserved between API calls
+    for ($i = 0; $i < 2; $i++) {
+      // create test contact
+      $contact_id = $this->callApiSuccess('Contact', 'create', [
+        'contact_type' => 'Individual',
+        'first_name' => 'Bpk',
+        'last_name' => 'Contact',
+      ])['id'];
+
+      $this->addDummyBpk($contact_id);
+
+      // update a field that should cause bpk reset
+      $this->callApiSuccess('Contact', 'create', [
+        'id' => $contact_id,
+        'first_name' => 'BpkUpd',
+      ]);
+
+      $expected = [
+        CRM_Bpk_CustomData::getCustomFieldKey('bpk', 'bpk_status') => BPK_STATUS_UNKNOWN,
+        CRM_Bpk_CustomData::getCustomFieldKey('bpk', 'bpk_extern') => '',
+        CRM_Bpk_CustomData::getCustomFieldKey('bpk', 'vbpk') => '',
+        CRM_Bpk_CustomData::getCustomFieldKey('bpk', 'bpk_error_code') => '',
+        CRM_Bpk_CustomData::getCustomFieldKey('bpk', 'bpk_error_note') => '',
+      ];
+      // get the (hopefully) updated BPK fields
+      $actual = $this->callApiSuccess('Contact', 'get', [
+        'id' => $contact_id,
+        'return' => array_keys($expected),
+      ]);
+      $actual = reset($actual['values']);
+      // verify that BPK fields were set to the default value
+      foreach ($expected as $key => $value) {
+        $this->assertEquals($value, $actual[$key], "BPK field {$key} should be reset to {$value}");
+      }
+    }
+  }
+
+  /**
+   * Add dummy BPK row. Go through SQL to avoid hooks
+   *
+   * @param $contact_id
+   */
+  private function addDummyBpk($contact_id) {
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_value_bpk
+                                         (entity_id, bpk_extern, vbpk, status, error_code, error_note)
+                                       VALUES
+                                         ({$contact_id}, '1234', '1234', " . BPK_STATUS_RESOLVED . ", 0, 'error')");
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,62 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
This fixes `CRM_Bpk_DataLogic::sendPendingBPKRequests()` to reset its state after handling a contact update and adds a basic unit test.

Fixes #1